### PR TITLE
Modified README to move the checksums section to a separate file. Added CODEOWNERS to support a two-group approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS for xygeni/xygeni
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# These owners will be automatically requested for review when a PR modifies matching files.
+# Branch protection rule "Require review from Code Owners" should be enabled on main.
+
+# Default: all files require review from the security team
+* @xygeni/security
+
+# Checksums are critical for supply-chain integrity verification
+/checksum/ @xygeni/security @xygeni/release-engineering

--- a/README.md
+++ b/README.md
@@ -65,37 +65,5 @@ Follow the instructions provided in the [Xygeni Quick Start](https://docs.xygeni
 
 ## Current checksums
 
-* `install.sh` (install script for Linux/macOS): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/install.sh.sha256)
-https://github.com/xygeni/xygeni/blob/90f2ea8874c400ae06980118173821b14dc7cf17/checksum/latest/install.sh.sha256?plain=1#L1
-
-* `install.ps1` (install script for Windows): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/install.ps1.sha256)
-https://github.com/xygeni/xygeni/blob/132b52b916e7eeba777b03b3c7fa1b3b671ce1f8/checksum/latest/install.ps1.sha256?plain=1#L1
-
-* `xygeni-release.zip` (scanner): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/xygeni-release.zip.sha256)
-https://github.com/xygeni/xygeni/blob/c72aa25133536bfbcebc455e911a046b1dae82d8/checksum/latest/xygeni-release.zip.sha256?plain=1#L1
-
-* `salt.zip` (build attestations): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/salt.zip.sha256)
-https://github.com/xygeni/xygeni/blob/e0cba2874f552418c958a3f4e7ecb8accc6aa8f9/checksum/latest/salt.zip.sha256?plain=1#L1
-
-So you may verify the integrity of a downloaded artifact. For example, for install scripts:
-
-* Under Linux / macOS:
-```
-# Download the install script from downloads area
-curl -sLO https://get.xygeni.io/latest/scanner/install.sh
-
-# Check the scanner checksum published in xygeni GitHub repo (separate environment)
-checksum="$(curl -s https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/install.sh.sha256)"
-echo "$checksum install.sh" | sha256sum --check
-```
-
-* Under Windows (PowerShell):
-```
-# Download the install script (via Invoke-WebRequest)
-iwr https://get.xygeni.io/latest/scanner/install.ps1 -useb -OutFile install.ps1
-
-# Check the scanner checksum
-(Get-FileHash '.\install.ps1' -Algorithm SHA256).Hash -eq `
-  (iwr https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/install.ps1.sha256)
-```
+See [checksum/CHECKSUMS.md](checksum/CHECKSUMS.md) for the full list of SHA-256 checksums and verification instructions for all downloadable artifacts (scanner, Salt CLI, bootstrap and install scripts).
 

--- a/checksum/CHECKSUMS.md
+++ b/checksum/CHECKSUMS.md
@@ -1,0 +1,63 @@
+# Current checksums
+
+SHA-256 checksums for the latest Xygeni downloadable artifacts, used for integrity verification.
+
+## Scanner
+
+* `get-xygeni.sh` (bootstrap script for Linux/macOS): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-xygeni.sh.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/get-xygeni.sh.sha256?plain=1#L1
+
+* `get-xygeni.ps1` (bootstrap script for Windows): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-xygeni.ps1.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/get-xygeni.ps1.sha256?plain=1#L1
+
+* `install.sh` (**deprecated** — use `get-xygeni.sh` instead): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/install.sh.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/install.sh.sha256?plain=1#L1
+
+* `install.ps1` (**deprecated** — use `get-xygeni.ps1` instead): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/install.ps1.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/install.ps1.sha256?plain=1#L1
+
+* `xygeni-release.zip` (scanner): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/xygeni-release.zip.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/xygeni-release.zip.sha256?plain=1#L1
+
+## Salt CLI
+
+* `get-salt.sh` (bootstrap script for Linux/macOS): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-salt.sh.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/get-salt.sh.sha256?plain=1#L1
+
+* `get-salt.ps1` (bootstrap script for Windows): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-salt.ps1.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/get-salt.ps1.sha256?plain=1#L1
+
+* `salt.zip` (build attestations): [checksum link](https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/salt.zip.sha256)
+https://github.com/xygeni/xygeni/blob/main/checksum/latest/salt.zip.sha256?plain=1#L1
+
+## Verification
+
+You may verify the integrity of a downloaded artifact before execution.
+
+### Linux / macOS
+
+```bash
+# Download and verify the bootstrap script
+curl -sLO https://get.xygeni.io/latest/scanner/get-xygeni.sh
+checksum="$(curl -s https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-xygeni.sh.sha256)"
+echo "$checksum get-xygeni.sh" | sha256sum --check
+
+# Same for Salt CLI
+curl -sLO https://get.xygeni.io/latest/salt/get-salt.sh
+checksum="$(curl -s https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-salt.sh.sha256)"
+echo "$checksum get-salt.sh" | sha256sum --check
+```
+
+### Windows (PowerShell)
+
+```powershell
+# Download and verify the bootstrap script
+iwr https://get.xygeni.io/latest/scanner/get-xygeni.ps1 -useb -OutFile get-xygeni.ps1
+(Get-FileHash '.\get-xygeni.ps1' -Algorithm SHA256).Hash -eq `
+  (iwr https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-xygeni.ps1.sha256)
+
+# Same for Salt CLI
+iwr https://get.xygeni.io/latest/salt/get-salt.ps1 -useb -OutFile get-salt.ps1
+(Get-FileHash '.\get-salt.ps1' -Algorithm SHA256).Hash -eq `
+  (iwr https://raw.githubusercontent.com/xygeni/xygeni/main/checksum/latest/get-salt.ps1.sha256)
+```


### PR DESCRIPTION

With CODEOWNERS on the xygeni/xygeni public repo, every pull request automatically requires approval from designated team owners before it can be merged into main. The * wildcard rule ensures @xygeni/security must      
review any change to any file, providing a security baseline for the entire repo. The /checksum/ rule additionally requires @xygeni/release-engineering, so checksum updates - the most supply-chain-critical files - need
approval from both teams. Combined with the branch protection rule "Require review from Code Owners", this prevents any single person from unilaterally modifying published checksums or other security-sensitive content,
enforcing a dual-approval workflow that mirrors the integrity guarantees the repo provides to users.
